### PR TITLE
Lock ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,16 +37,17 @@ lock_api = "0.2.0"
 parking_lot = "0.8.0"
 parking_lot_core = "0.5.0"
 swym-htm = { path = "./swym-htm", version = "0.1.0" }
+priority-queue = "1.0.0"
 
 [dev-dependencies]
 jemallocator = "0.3.0"
 
 [profile.bench]
 opt-level = 3
-debug = false
+debug = true
 rpath = false
 lto = "fat"
-debug-assertions = false
+debug-assertions = true
 codegen-units = 1
 incremental = false
 overflow-checks = false

--- a/src/internal/commit.rs
+++ b/src/internal/commit.rs
@@ -86,7 +86,6 @@ impl<'tcell> WriteLog<'tcell> {
         for entry in self.write_entries() {
             unsafe { entry.perform_write() };
             status = status.merge(entry.try_lock_htm(htx, pin_epoch));
-            println!("{:?}", entry.data_ptr());
         }
         status
     }

--- a/src/internal/commit.rs
+++ b/src/internal/commit.rs
@@ -12,6 +12,7 @@ use core::{
     sync::atomic::{self, Ordering::Release},
 };
 use swym_htm::{BoundedHtxErr, HardwareTx};
+use priority_queue::PriorityQueue;
 
 const MAX_HTX_RETRIES: u8 = 3;
 
@@ -69,7 +70,13 @@ impl<'tcell> dyn WriteEntry + 'tcell {
 impl<'tcell> WriteLog<'tcell> {
     #[inline]
     unsafe fn publish(&self, sync_epoch: QuiesceEpoch) {
-        self.epoch_locks()
+        let mut q = PriorityQueue::new();
+        for lock in self.epoch_locks(){
+            let weight = std::mem::transmute::<&EpochLock, usize>(lock);
+            q.push(lock, weight);
+        }
+        let sorted_vec = q.into_sorted_vec();
+        sorted_vec.iter()
             .for_each(|epoch_lock| epoch_lock.unlock_publish(sync_epoch))
     }
 
@@ -79,6 +86,7 @@ impl<'tcell> WriteLog<'tcell> {
         for entry in self.write_entries() {
             unsafe { entry.perform_write() };
             status = status.merge(entry.try_lock_htm(htx, pin_epoch));
+            println!("{:?}", entry.data_ptr());
         }
         status
     }
@@ -194,11 +202,19 @@ impl<'tx, 'tcell> PinRw<'tx, 'tcell> {
         let mut park_status = ParkStatus::NoParked;
         let pin_epoch = self.pin_epoch();
         let mut unlock_until = None;
-        for epoch_lock in logs.write_log.epoch_locks() {
+        
+        //SORT LOCKS
+        let mut q = PriorityQueue::new();
+        for lock in logs.write_log.epoch_locks(){
+            let weight = unsafe {std::mem::transmute::<&EpochLock, usize>(lock)};
+            q.push(lock, weight);
+        }
+        let sorted_vec = q.into_sorted_vec();
+        for epoch_lock in sorted_vec.iter() {
             match epoch_lock.try_lock(pin_epoch) {
                 Some(cur_status) => park_status = park_status.merge(cur_status),
                 None => {
-                    unlock_until = Some(epoch_lock as *const _);
+                    unlock_until = Some(*epoch_lock as *const _);
                     break;
                 }
             }

--- a/src/internal/epoch.rs
+++ b/src/internal/epoch.rs
@@ -230,11 +230,7 @@ impl EpochLock {
     pub const fn first() -> Self {
         EpochLock(HtmStorage::new(FIRST))
     }
-/*
-    pub const fn lock_number(&self, f: &mut Formatter<'_>) -> String {
-        f.debug_struct("EpochLock").field("epoch", &as_unlocked(self.load_raw(Relaxed).get())).finish()
-    }
-*/
+    
     #[inline]
     fn load_raw(&self, o: Ordering) -> NonZeroStorage {
         let value = self.0.load(o);

--- a/src/internal/write_log.rs
+++ b/src/internal/write_log.rs
@@ -34,24 +34,9 @@ impl<'tcell, T> WriteEntryImpl<'tcell, T> {
 
 pub unsafe trait WriteEntry {}
 unsafe impl<'tcell, T> WriteEntry for WriteEntryImpl<'tcell, T> {}
-/*
-impl PartialEq for dyn WriteEntry{
-    fn eq(&self, other: &dyn WriteEntry) -> bool {
-        ptr::eq(self.tcell().map(|erased| &erased.current_epoch).unwrap(),other.tcell().map(|erased| &erased.current_epoch).unwrap())
-    }
-}
-
-impl Eq for dyn WriteEntry{}
-
-impl Hash for dyn WriteEntry {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let address  = unsafe {std::mem::transmute::<&EpochLock, usize>(self.tcell().map(|erased| &erased.current_epoch).unwrap()) };
-        address.hash(state);
-    }
-}*/
 
 impl<'tcell> dyn WriteEntry + 'tcell {
-    pub fn data_ptr(&self) -> NonNull<usize> {
+    fn data_ptr(&self) -> NonNull<usize> {
         debug_assert!(
             mem::align_of_val(self) >= mem::align_of::<NonNull<usize>>(),
             "incorrect alignment on data_ptr"
@@ -179,7 +164,7 @@ impl<'tcell> WriteLog<'tcell> {
         Option<&'a EpochLock>,
         impl FnMut(&'a (dyn WriteEntry + 'tcell)) -> Option<&'a EpochLock>,
     > {
-        /*
+        /* First (and not final) attempt at soring here rather than after call
         let iterator = self.data.iter();
         let mut q = PriorityQueue::new();
         for lock in iterator{
@@ -195,16 +180,16 @@ impl<'tcell> WriteLog<'tcell> {
         }
         // ATTEMP TO CONVERT TO VTABLE: let new_iter = crate::internal::alloc::dyn_vec::vtable::<dyn WriteEntry + 'tcell>(&new_vec.iter());
         let new_iter = new_vec.iter();
-       */
+       
         //let map = self.data.iter().flat_map(|entry| {entry.tcell().map(|erased| &erased.current_epoch)});
         //let new_vec : Vec< &'a EpochLock>  = map.collect();
-        let new_map = self.data.iter().flat_map(|entry| {entry.tcell().map(|erased| &erased.current_epoch)});
-        return new_map;
+        */
+        self.data.iter().flat_map(|entry| {entry.tcell().map(|erased| &erased.current_epoch)})
     }
 
     #[inline]
     pub fn write_entries<'a>(
-         &'a self,
+        &'a self,
     ) -> crate::internal::alloc::dyn_vec::Iter<'a, (dyn WriteEntry + 'tcell)> {
         self.data.iter()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(unused_must_use)]
-
+#![feature(negative_impls)]
 #[macro_use]
 mod internal;
 


### PR DESCRIPTION
Lock sorting by memory address done after each call to epoch_locks() in commit.rs/write_log.rs/read_log.rs using a priority queue.